### PR TITLE
fixes rizon nick matching

### DIFF
--- a/plugins/tell.py
+++ b/plugins/tell.py
@@ -99,7 +99,7 @@ def tell(inp, nick='', chan='', db=None, input=None, notice=None):
         notice("Thanks for the message, %s!" % user_from)
         return
 
-    if not re.match("^[A-Za-z0-9_|.\-\]\[]*$", user_to.lower()):
+    if not re.match("^([A-Za-z0-9_.|`\^\-\[\]])+$", user_to.lower()):
         notice("I cant send a message to that user!")
         return
 


### PR DESCRIPTION
currently the bot can't send a message to users which have `^`, `-`, or a backtick on their nick. this should fix that.

(also i didnt test it)