### PR TITLE
fix hashtag pastebin format

### DIFF
--- a/plugins/hashtags.py
+++ b/plugins/hashtags.py
@@ -213,7 +213,10 @@ def hashes(inp, say=None, db=None, bot=None, me=None, conn=None, input=None):
         pastebin_vars = {
             'api_dev_key': bot.config.get('api_keys', {}).get('pastebin'),
             'api_option': 'paste',
-            'api_paste_code': output.encode('utf-8')
+            'api_paste_code': ("\n".join(output)).encode('utf-8'),
+            'api_paste_name': 'search result',
+            'api_paste_private': 1,
+            'api_paste_expire_date': '1W'
         }
         response = urllib.urlopen('http://pastebin.com/api/api_post.php',
                                   urllib.urlencode(pastebin_vars))


### PR DESCRIPTION
the `.hashes` output was being uploaded to pastebin and it was [one important mess to behold](https://pastebin.com/4w51THTg), so i've imploded the output array with newlines instead of uploading some serialized thing. utf8 should still work.

also i've added an expiration date of one week to the search results.

obviously, i didn't test.