### PR TITLE
avoid lxml in urls.py, fixes broken utf-8

### DIFF
--- a/plugins/mediawiki.py
+++ b/plugins/mediawiki.py
@@ -9,12 +9,12 @@ INSTANCES = {
     'encyclopediadramatica': {
         'name': 'Encyclopedia Dramatica',
         'search': 'https://encyclopediadramatica.wiki/api.php?' + API_QUERYPARAMS,
-        'regex': r'(https?://encyclopediadramatica\.wiki/index\.php/(.*))'
+        'regex': r'(https?://encyclopediadramatica\.wiki/index\.php/[^ ]+)'
     },
     'wikipedia_en': {
         'name': 'Wikipedia',
         'search': 'https://en.wikipedia.org/w/api.php?' + API_QUERYPARAMS,
-        'regex': r'(https?://en\.wikipedia\.org/wiki/(.*))'
+        'regex': r'(https?://en\.wikipedia\.org/wiki/[^ ]+)'
     },
 }
 


### PR DESCRIPTION
lxml tries to guess encoding and fails, puking mojibake everywhere.

this change avoids lxml and just grabs the text between `<title>` and `</title>`. it can fail for some weirdly formatted html (or for xhtml 4 `<TITLE>`) but its enough to cover most cases. should be faster, too.


also i changed the mediawiki regex cuz it was too greedy