### PR TITLE
urls.py: small changes, partially fix #37

### DIFF
--- a/plugins/urls.py
+++ b/plugins/urls.py
@@ -208,7 +208,7 @@ def hentai_url(match, bot):
         return u'{}'.format(soup.title.string)
 
 
-user_agent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:35.0) Gecko/20100101 Firefox/35.0'
+user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138'
 headers = {'User-Agent': user_agent}
 
 

--- a/plugins/urls.py
+++ b/plugins/urls.py
@@ -266,6 +266,7 @@ def unmatched_url(url, parsed, bot, chan, db):
     # parsing
     domain = parsed.netloc
     content_type = req.headers.get('Content-Type', '')
+    size = req.headers.get('Content-Length', 0)
     output = ['[URL]']
 
     if 'html' in content_type:
@@ -275,21 +276,46 @@ def unmatched_url(url, parsed, bot, chan, db):
             print '[!] WARNING the url caused a parser error'
             title = 'Untitled'
 
+        # TODO handle titles with html entities
+        if '&' in title and ';' in title:
+            # pls fix
+            title = title.replace('&quot;', '"')
+
+        # fucking cloudflare
+        if 'Attention Required! | Cloudflare' in title:
+            return
+
         output.append(title)
 
     else:
         if 'filesize' in disabled_commands:
             return
 
-        if 'image' in content_type:
+        # very common mime types
+        if 'image/' in content_type:
             output.append(content_type.replace('image/', '') + ' image,')
+        elif 'video/' in content_type:
+            output.append(content_type.replace('video/', '') + ' video,')
+        elif 'text/' in content_type:
+            output.append('text file,')
+        elif 'application/octet-stream' == content_type:
+            output.append('binary file,')
+        elif 'audio/' in content_type:
+            output.append('audio file,')
+
+        # other mime types
+        elif 'application/vnd.' in content_type:
+            output.append('unknown binary file,')
+        elif 'font/' in content_type:
+            output.append('font,')
+
+        # i dunno
         else:
             output.append(content_type + ' file,')
 
-        size = req.headers.get('Content-Length', 0)
         try:
             size = int(size)
-        except:
+        except TypeError:
             size = 0
 
         # some pages send exactly 503 or 513 bytes of empty padding as an

--- a/plugins/urls.py
+++ b/plugins/urls.py
@@ -217,7 +217,7 @@ def parse_html(stream):
     for chunk in stream.iter_content(chunk_size=256):
         data = data + chunk
 
-        if len(data) > (1024 * 4):  # use only first 4 KiB
+        if len(data) > (1024 * 12):  # use only first 12 KiB
             break
 
     # try to quickly grab the content between <title> and </title>


### PR DESCRIPTION
fixes some issues in #37

- handle common mime types
  - show prettier output
  - hides `text/blahblah; charset=utf-8`
- ignore cloudflare blocks
- update user agent

still haven't handled html entities